### PR TITLE
Fix for deploy on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./node_modules/.bin/webpack-devserver --inline
+web: ./node_modules/.bin/http-server dist/ -p $PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: webpack-devserver --inline
+web: node_modules/.bin/webpack-devserver --inline

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: webpack-devserver --inline

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node_modules/.bin/webpack-devserver --inline
+web: ./node_modules/.bin/webpack-devserver --inline

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "In this sample we are going to evaluate different progress bar options.",
   "main": "index.js",
   "scripts": {
+    "postinstall": "webpack",
     "start": "webpack-devserver --inline",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -21,6 +22,7 @@
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.22.0",
+    "http-server": "^0.9.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "style-loader": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "In this sample we are going to evaluate different progress bar options.",
   "main": "index.js",
   "scripts": {
-    "postinstall": "webpack",
+    "postinstall": "webpack", 
     "start": "webpack-devserver --inline",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Html5Progressbar } from './html5Progressbar';
 import { BootstrapProgressbar } from './bootstrapProgressbar';
-import { ProgressBarComponent } from './progressBar/ProgressBarComponent';
+import { ProgressBarComponent } from './progressBar/progressBarComponent';
 
 interface Props {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
        contentBase: './dist', //Content base
        inline: true, //Enable watch and live reload
        host: 'localhost',
-       port: 8080,
+       port: process.env.PORT || 8080,
        stats: 'errors-only'
   },
 


### PR DESCRIPTION
**Fixes:**

1. Heroku needs you to use the PORT env var instead of using a fixed one like 8080
2. Heroku for nodejs, by default, only installs production depenences and not devDependences. To override this, set the config var `NPM_CONFIG_PRODUCTION=false` as explained here https://devcenter.heroku.com/articles/nodejs-support#devdependencies
3. Preffer using http-server for production instead of webpack-devel (but just a choice)
4. Missing Procfile for Heroku.
5. Fixed very subtle issue about naming files. PascalCase to camelcase reference. Not noticeable on Windows, but enough to fail on a case-sentitive OS like linux (base for heroku).

Enjoy!